### PR TITLE
Add nested attribute field to administrate

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby "2.3.0"
 
 gem "administrate", "~> 0.2.0"
 gem "administrate-field-image"
+gem "administrate-field-nested_has_many", "~> 0.0.2"
 gem "autoprefixer-rails"
 gem "bourbon"
 gem "clearance", "~> 1.14.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,10 @@ GEM
     administrate-field-image (0.0.2)
       administrate (>= 0.2.0.rc1, < 0.3.0)
       rails (~> 4.2)
+    administrate-field-nested_has_many (0.0.2)
+      administrate (~> 0.2.0)
+      cocoon (~> 1.2)
+      rails (~> 4.2)
     arel (6.0.3)
     ast (2.2.0)
     autoprefixer-rails (6.3.6.1)
@@ -87,6 +91,7 @@ GEM
       bcrypt
       email_validator (~> 1.4)
       rails (>= 3.1)
+    cocoon (1.2.9)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
     crack (0.4.3)
@@ -313,6 +318,7 @@ PLATFORMS
 DEPENDENCIES
   administrate (~> 0.2.0)
   administrate-field-image
+  administrate-field-nested_has_many (~> 0.0.2)
   autoprefixer-rails
   awesome_print
   bourbon

--- a/app/dashboards/fantasy_player_dashboard.rb
+++ b/app/dashboards/fantasy_player_dashboard.rb
@@ -15,7 +15,7 @@ class FantasyPlayerDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     final_rankings: Field::NestedHasMany.
-      with_options(skip: :fantasy_player),
+                     with_options(skip: :fantasy_player),
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/fantasy_player_dashboard.rb
+++ b/app/dashboards/fantasy_player_dashboard.rb
@@ -14,6 +14,8 @@ class FantasyPlayerDashboard < Administrate::BaseDashboard
     final_rankings: Field::HasMany,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
+    final_rankings: Field::NestedHasMany.
+      with_options(skip: :fantasy_player),
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -43,6 +45,7 @@ class FantasyPlayerDashboard < Administrate::BaseDashboard
   FORM_ATTRIBUTES = [
     :name,
     :sports_league,
+    :final_rankings,
   ].freeze
 
   # Overwrite this method to customize how fantasy players are displayed

--- a/app/dashboards/roster_transaction_dashboard.rb
+++ b/app/dashboards/roster_transaction_dashboard.rb
@@ -19,7 +19,7 @@ class RosterTransactionDashboard < Administrate::BaseDashboard
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     transaction_line_items: Field::NestedHasMany.
-      with_options(skip: :roster_transaction),
+                     with_options(skip: :roster_transaction),
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/roster_transaction_dashboard.rb
+++ b/app/dashboards/roster_transaction_dashboard.rb
@@ -18,6 +18,8 @@ class RosterTransactionDashboard < Administrate::BaseDashboard
     roster_transaction_on: Field::DateTime,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
+    transaction_line_items: Field::NestedHasMany.
+      with_options(skip: :roster_transaction),
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -51,6 +53,7 @@ class RosterTransactionDashboard < Administrate::BaseDashboard
     :roster_transaction_type,
     :roster_transaction_on,
     :additional_terms,
+    :transaction_line_items,
   ].freeze
 
   # Overwrite this method to customize how roster transactions are displayed

--- a/app/models/fantasy_player.rb
+++ b/app/models/fantasy_player.rb
@@ -7,6 +7,8 @@ class FantasyPlayer < ActiveRecord::Base
   has_many :transaction_line_item_details
   belongs_to :sports_league
 
+  accepts_nested_attributes_for :final_rankings, allow_destroy: true
+
   validates :name, presence: true
 
   def self.with_all_details

--- a/app/models/roster_transaction.rb
+++ b/app/models/roster_transaction.rb
@@ -3,6 +3,7 @@ class RosterTransaction < ActiveRecord::Base
   has_many :fantasy_teams, through: :transaction_line_items
   has_many :transaction_line_items, dependent: :destroy
   has_many :transaction_line_item_details
+
   accepts_nested_attributes_for :transaction_line_items, allow_destroy: true
 
   enum roster_transaction_type: {

--- a/app/models/roster_transaction.rb
+++ b/app/models/roster_transaction.rb
@@ -3,6 +3,7 @@ class RosterTransaction < ActiveRecord::Base
   has_many :fantasy_teams, through: :transaction_line_items
   has_many :transaction_line_items, dependent: :destroy
   has_many :transaction_line_item_details
+  accepts_nested_attributes_for :transaction_line_items, allow_destroy: true
 
   enum roster_transaction_type: {
     "initial draft" => 1, "mid season draft" => 2, "waiver claim" => 3,

--- a/app/views/admin/application/_javascript.html.erb
+++ b/app/views/admin/application/_javascript.html.erb
@@ -1,0 +1,20 @@
+<%#
+# Javascript Partial
+
+This partial imports the necessary javascript on each page.
+By default, it includes the application JS,
+but each page can define additional JS sources
+by providing a `content_for(:javascript)` block.
+%>
+
+<%= javascript_include_tag "administrate/application" %>
+<%= javascript_include_tag "administrate-field-nested_has_many/application" %>
+
+<%= yield :javascript %>
+
+<% if Rails.env.test? %>
+  <%= javascript_tag do %>
+    $.fx.off = true;
+    $.ajaxSetup({ async: false });
+  <% end %>
+<% end %>

--- a/app/views/fields/belongs_to/_form.html.erb
+++ b/app/views/fields/belongs_to/_form.html.erb
@@ -1,0 +1,24 @@
+<%#
+# BelongsTo Form Partial
+
+This partial renders an input element for belongs_to relationships.
+By default, the input is a collection select box
+that displays all possible records to associate with.
+
+## Local variables:
+
+- `f`:
+  A Rails form generator, used to help create the appropriate input fields.
+- `field`:
+  An instance of [Administrate::Field::BelongsTo][1].
+  Contains helper methods for displaying a collection select box.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/BelongsTo
+%>
+
+<div class="field-unit__label">
+  <%= f.label field.permitted_attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.select(field.permitted_attribute, field.associated_resource_options) %>
+</div>

--- a/spec/features/admin_visits_admin_dashboard_spec.rb
+++ b/spec/features/admin_visits_admin_dashboard_spec.rb
@@ -42,7 +42,24 @@ feature "admin visits admin dashboard" do
     click_on "Create Final ranking"
 
     expect(page).to have_css(".flash",
-      text: "FinalRanking was successfully created.")
+                             text: "FinalRanking was successfully created.")
+  end
+
+  scenario "and creates final ranking from fantasy player page", js: true do
+    create_admin
+    create(:fantasy_player, name: "Seattle Seahawks")
+
+    sign_in_with("admin@example.com", "password")
+    visit_admin_to_edit "Fantasy Players"
+    click_on "Add Final Ranking"
+    fill_in "Year", with: 2016
+    fill_in "Rank", with: 1
+    fill_in "Points", with: 8
+    fill_in "Winnings", with: 25
+    click_on "Update Fantasy player"
+
+    expect(page).to have_css(".flash",
+                             text: "FantasyPlayer was successfully updated.")
   end
 
   scenario "and adds fantasy player to fantasy team" do
@@ -58,7 +75,7 @@ feature "admin visits admin dashboard" do
     click_on "Create Roster position"
 
     expect(page).to have_css(".flash",
-      text: "RosterPosition was successfully created.")
+                             text: "RosterPosition was successfully created.")
   end
 
   scenario "and creates a fantasy league" do
@@ -72,7 +89,7 @@ feature "admin visits admin dashboard" do
     click_on "Create Fantasy league"
 
     expect(page).to have_css(".flash",
-      text: "FantasyLeague was successfully created.")
+                             text: "FantasyLeague was successfully created.")
   end
 
   scenario "and updates a user to an admin" do


### PR DESCRIPTION
Using the administrate plugin, added nested attribute fields in the administrate edit pages for roster transaction and final ranking
